### PR TITLE
Explicitly provide text for POD links

### DIFF
--- a/lib/Pod/Weaver/Section/Requires.pm
+++ b/lib/Pod/Weaver/Section/Requires.pm
@@ -82,7 +82,7 @@ sub weave_section {
 			map {
 				Command->new( {
 					command => 'item',
-					content => "* L<$_>",
+					content => "* L<$_|$_>",
 				} ),
 			} @modules
 		),


### PR DESCRIPTION
This practice is recommended by [Perl::Critic::Policy::Documentation::RequirePodLinksIncludeText](https://metacpan.org/pod/Perl::Critic::Policy::Documentation::RequirePodLinksIncludeText).
